### PR TITLE
[ADD] database connection established

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ lerna-debug.log*
 .env
 docker-compose.yml
 Dockerfile
+deployment.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.4.2",
+        "@nestjs/typeorm": "^9.0.1",
         "bcrypt": "^5.1.0",
         "dotenv": "^16.1.4",
         "jsonwebtoken": "^9.0.0",
@@ -1606,6 +1607,29 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/typeorm": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-9.0.1.tgz",
+      "integrity": "sha512-A2BgLIPsMtmMI0bPKEf4bmzgFPsnvHqNBx3KkvaJ7hJrBQy0OqYOb+Rr06ifblKWDWS2tUPNrAFQbZjtk3PI+g==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0",
+        "reflect-metadata": "^0.1.13",
+        "rxjs": "^7.2.0",
+        "typeorm": "^0.3.0"
+      }
+    },
+    "node_modules/@nestjs/typeorm/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.4.2",
+    "@nestjs/typeorm": "^9.0.1",
     "bcrypt": "^5.1.0",
     "dotenv": "^16.1.4",
     "jsonwebtoken": "^9.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import dataSource from './utils/db.config';
 
 @Module({
-  imports: [],
+  imports: [TypeOrmModule.forRoot(dataSource)],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/chats/chatLogs.entity.ts
+++ b/src/chats/chatLogs.entity.ts
@@ -1,0 +1,41 @@
+import { User } from 'src/users/users.entity';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ChatRoom } from './chatRooms.entity';
+
+@Entity({ name: 'ChatLogs' })
+export class ChatLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: number;
+
+  @Column({ type: 'int', nullable: false })
+  chatroom_id: number;
+
+  @Column({ type: 'int', nullable: false })
+  sender_id: number;
+
+  @Column({ type: 'longtext', nullable: false })
+  content: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @DeleteDateColumn()
+  deleted_at: Date;
+
+  @ManyToOne(() => User, (user) => user.sentChats, { onDelete: 'CASCADE' })
+  sender: User;
+
+  @ManyToOne(() => ChatRoom, (chatRoom) => chatRoom.chatLogs)
+  chatRoom: ChatRoom;
+}

--- a/src/chats/chatRooms.entity.ts
+++ b/src/chats/chatRooms.entity.ts
@@ -1,0 +1,57 @@
+import { User } from 'src/users/users.entity';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ChatLog } from './chatLogs.entity';
+
+@Entity({ name: 'ChatRooms' })
+export class ChatRoom {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ default: false, nullable: false })
+  is_secret: boolean;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  keyword: string;
+
+  @Column({ type: 'int', nullable: false })
+  host_id: number;
+
+  @Column({ type: 'int', nullable: false })
+  guest_id: number;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  room_name_host: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  room_name_guest: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  expires_at: Date;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @DeleteDateColumn()
+  deleted_at: Date;
+
+  @ManyToOne(() => User, (user) => user.hostedChatRooms)
+  host: User;
+
+  @ManyToOne(() => User, (user) => user.joinedChatRooms)
+  guest: User;
+
+  @OneToMany(() => ChatLog, (chatLog) => chatLog.chatRoom)
+  chatLogs: ChatLog[];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   app.enableCors();
 
-  const port = process.env.PORT;
+  const port = process.env.SERVER_PORT;
   await app.listen(port);
 
   console.log(`Application is running on: ${await app.getUrl()}`);

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -1,0 +1,57 @@
+import { ChatLog } from 'src/chats/chatLogs.entity';
+import { ChatRoom } from 'src/chats/chatRooms.entity';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity({ name: 'Users' })
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  email: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  password: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  name: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  nickname: string;
+
+  @Column({ type: 'longtext', nullable: true })
+  token: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  last_login_at: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  last_logout_at: Date;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @DeleteDateColumn()
+  deleted_at: Date;
+
+  // Relationship Declaration
+  @OneToMany(() => ChatRoom, (chatRoom) => chatRoom.host)
+  hostedChatRooms: ChatRoom[];
+
+  @OneToMany(() => ChatRoom, (chatRoom) => chatRoom.guest)
+  joinedChatRooms: ChatRoom[];
+
+  @OneToMany(() => ChatLog, (chatLog) => chatLog.sender)
+  sentChats: ChatLog[];
+}

--- a/src/utils/db.config.ts
+++ b/src/utils/db.config.ts
@@ -1,0 +1,49 @@
+import { User } from 'src/users/users.entity';
+import { DataSource, Entity } from 'typeorm';
+import { MysqlConnectionOptions } from 'typeorm/driver/mysql/MysqlConnectionOptions';
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { ChatRoom } from 'src/chats/chatRooms.entity';
+import { ChatLog } from 'src/chats/chatLogs.entity';
+import { configDotenv } from 'dotenv';
+
+configDotenv();
+
+const type = process.env.DB_MYSQL_CONNECTION;
+const port = process.env.DB_MYSQL_PORT;
+const username = process.env.DB_MYSQL_USERNAME;
+const password = process.env.DB_MYSQL_PASSWORD;
+const host = process.env.DB_MYSQL_HOST;
+const prefix = process.env.DB_MYSQL_PREFIX;
+const postfix = process.env.DB_MYSQL_POSTFIX;
+
+// <============== Connection Acquired without @nest/typeorm ==============>
+/*
+ * const mysqlConnectionOpt: MysqlConnectionOptions = {
+ *  type: 'mysql',
+ *  port: parseInt(port),
+ *  host: host,
+ *  username: username,
+ *  password: password,
+ *  database: prefix + '_' + postfix,
+ *  entities: [User],
+ *  synchronize: true, // should be disabled in production environment
+ * };
+ *
+ * const dataSource: DataSource = new DataSource(mysqlConnectionOpt);
+ *
+ */
+
+// <=============== Connection Acquired with @nest/typeorm ================>
+
+const dataSource: TypeOrmModuleOptions = {
+  type: 'mysql',
+  port: parseInt(port),
+  host: host,
+  username: username,
+  password: password,
+  database: prefix + '_' + postfix,
+  entities: [User, ChatRoom, ChatLog],
+  synchronize: true, // should be disabled in production environment
+};
+
+export default dataSource;


### PR DESCRIPTION
mysql2와 TypeORM과 @nestjs/typeorm로 DB 연결
[TypeOrm Documentation(Official)](https://typeorm.io/entities)
[TypeOrm Documentation(Custom)](https://orkhan.gitbook.io/typeorm/docs/decorator-reference#createdatecolumn)

주요 포인트:
1. nest proejct에서 orm으로 typeorm을 사용할 때는 typeorm만으로 DB와 서버를 연결하는 것보다는 @nestjs/typeorm으로 연결을 하는 것이 어플리케이션의 모듈 파일에 연결하기가 편하다.

2. `TypeOrmModule.forFeature()`와 `TypeOrmModule.forRoot()` 차이:
   - TypeOrmModule은 TypeOrmModuleOptions 타입의 파라미터를 받는다.
   - TypeOrmModuleOptions는 retryAttempts(DB 연결 재시도 횟수), retryDelay(DB 연결 재시도 간 시간(딜레이)), toRetry(재시도 여부), keepConnectionAlive(연결 실패 시 에러 메세지 표시)와 DataSourceOptions 타입에 종속된 타입들의 인자들을 파라미터로 받는다. DataSourceOptions는 DBMS의 종류에 따라 달라지며, 보통 type(DBMS의 타입), port(포트 번호), host(호스트 엔드포인트), username(DB 서버의 유저 이름), password(DB 서버의 비밀번호), database(사용할 DB 이름), entities(엔티티), synchronize(엔티티 파일들과 SQL 스키마 동기화 여부) 등이 있는데, forFeature와 forRoot이 엔티티 클래스 배열의 지목 방법에 따라 차이가 난다.
   - forFeature은 엔티티들이 directory path로 지목되어 있을 때 사용한다.
   - forRoot는 엔티티들이 클래스 배열로 나열되어 있을 때 사용한다.
   
3. TypeOrm의 Entity Decorator 종류 
   - `@Column()`: 테이블의 칼럼을 생성한다. 인자로 객체를 입력할 수 있는데, type(SQL data type), length(length limit), nullable, default(default value. Must be entered in callback function) 등의 인자로 SQL 상의 설정 값들을 입력할 수 있다.
   - `@PrimaryGeneratedColumn()`: auto incrementing primary key column을 생성한다.
   - `@CreateDateColumn()`: 생성 시간 칼럼을 생성한다.
   - `@UpdateDateColumn()`: 수정 시간 칼럼을 생성한다.
   - `@DeleteDateColumn()`: 삭제 시간 칼럼을 생성한다.
   
4. 관계 설정
   - entity 상에서 테이블 간의 관계를 decorator로 설정할 수 있다. 
   - 기본 syntax:
   `@RELATION_DECORATOR( () => ENTITY_CLASS, (eachRow) => eachRow.RELATION_PROPERTY_NAME )
   RELATION_PROPERTY_NAME: ENTITY_CLASS or ENTITY_CLASS[]`
   - `@OneToOne`: 1 대 1
   - `@OneToMany`: 1 대 다
   - `@ManyToOne`: 다 대 1
   - `@ManyToMany`: 다 대 다